### PR TITLE
ci(release): set default to main branch

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,3 @@
+{
+  "branches": ["main"]
+}


### PR DESCRIPTION
Due to an issue with the `main` branch with Semantic Release, we need to add a configuration to define it.